### PR TITLE
Bring back lost reference files for Greengenes 13.8

### DIFF
--- a/ci/recipe/build.sh
+++ b/ci/recipe/build.sh
@@ -3,6 +3,15 @@
 set -e
 set -x
 
+# extract Greengenes 13.8 reference files
+tar xjvf vendor/sepp-refs/gg/sepp-package.tar.bz sepp-package-gg/ref/
+
+mkdir -p sepp-package/ref/
+mv sepp-package-gg/ref/99_otu_taxonomy.txt                         sepp-package/ref/
+mv sepp-package-gg/ref/gg_13_5_ssu_align_99_pfiltered.fasta        sepp-package/ref/
+mv sepp-package-gg/ref/RAxML_info-reference-gg-raxml-bl.info       sepp-package/ref/
+mv sepp-package-gg/ref/reference-gg-raxml-bl-rooted-relabelled.tre sepp-package/ref/
+
 # extract Silva reference files
 tar xjvf vendor/sepp-refs/silva/sepp-package-silva.tar.bz sepp-package-silva/ref/
 tar xjvf vendor/sepp-refs/silva/sepp-package-silva-2.tar.bz sepp-package-silva/ref/


### PR DESCRIPTION
I think the switch from sepp-ref git repo to bioconda package of sepp caused loosing the Greengenes 13.8 default reference files.

We now need to manually add them during the q2 package creation.