### PR TITLE
avoid file format sniffing, for speed-up

### DIFF
--- a/q2_fragment_insertion/_insertion.py
+++ b/q2_fragment_insertion/_insertion.py
@@ -27,7 +27,7 @@ from q2_fragment_insertion._format import PlacementsFormat, SeppReferenceDirFmt
 # which is not necessarily true for SEPP produced insertion trees. We add zero
 # branch length information for branches without an explicit length.
 def _add_missing_branch_length(tree_fp):
-    tree = skbio.TreeNode.read(tree_fp)
+    tree = skbio.TreeNode.read(tree_fp, format="newick")
     for node in tree.preorder():
         if node.length is None:
             node.length = 0


### PR DESCRIPTION
we might want to explicitly read as `format="newick"` to save run-time: see https://github.com/biocore/scikit-bio/issues/1825