### PR TITLE
LANG: relax dendropy pin for python 3.10 update

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -25,9 +25,7 @@ requirements:
     - q2-types {{ qiime2_epoch }}.*
     - sepp
     - ijson
-    # they imported a private function which doesn't exist anymore...
-    # https://github.com/smirarab/sepp/blob/66cf22cfb9ca22ed9e9074984018d099617b3c6a/sepp/tree.py#L25
-    - dendropy 4.5.2
+    - dendropy
 
 test:
   requires:


### PR DESCRIPTION
Seems like dendropy no longer needs to be pinned as of the latest sepp release (which is on bioconda)
https://github.com/smirarab/sepp/issues/125#issuecomment-2316392621

Let's see what happens!