### PR TITLE
MAINT: fragment-insertion deprecation

### DIFF
--- a/q2_fragment_insertion/plugin_setup.py
+++ b/q2_fragment_insertion/plugin_setup.py
@@ -33,6 +33,7 @@ plugin = qiime2.plugin.Plugin(
 
 
 plugin.methods.register_function(
+    deprecated=True,
     function=q2_fragment_insertion.sepp,
     inputs={
         'representative_sequences': FeatureData[Sequence],
@@ -84,6 +85,7 @@ plugin.methods.register_function(
 
 
 plugin.methods.register_function(
+    deprecated=True,
     function=q2_fragment_insertion.classify_otus_experimental,
     inputs={
         'representative_sequences': FeatureData[Sequence],
@@ -115,6 +117,7 @@ plugin.methods.register_function(
 
 
 plugin.methods.register_function(
+    deprecated=True,
     function=q2_fragment_insertion.filter_features,
     inputs={
         'table': FeatureTable[Frequency],


### PR DESCRIPTION
Adding notes on this so I don't forget to add to the 2025.7 changelog.

Fragment Insertion Deprecation Plan (2025.7 release)
-------------------------------------
**Key reasons:**
- Dependency issues blocking Python version updates
- 10-year-old software causing ongoing maintenance challenges
- Alternative solutions available (kmerizer, conventional phylogenetics)

**Migration path:**
- Will maintain in Docker container (users can continue using 2025.7 version)
- Documentation needed for cross-distribution workflows
- Plan to announce with 2025.7 release
